### PR TITLE
Fixes compilation issue + proper detection of 4K tags

### DIFF
--- a/mfterm.c
+++ b/mfterm.c
@@ -21,6 +21,7 @@
  */
 
 #include <stdlib.h>
+#include <stdio.h>
 #include <readline/readline.h>
 #include <readline/history.h>
 #include "term_cmd.h"

--- a/mifare_ctrl.c
+++ b/mifare_ctrl.c
@@ -111,10 +111,13 @@ int mf_setup(nfc_device_t** device /* out */,
   }
 
   // Guessing tag size
-  if ((target->nti.nai.abtAtqa[1] & 0x02)) // 4K
+  if ((target->nti.nai.abtAtqa[1] & 0x02)) { // 4K
     *size = MF_4K;
-  if ((target->nti.nai.abtAtqa[1] & 0x04)) // 1K
+  }
+  else
+  if ((target->nti.nai.abtAtqa[1] & 0x04)) { // 1K
     *size = MF_1K;
+  }
   else {
     printf("Unsupported tag size [1|4]K.\n");
     goto err; // Disconnect and return


### PR DESCRIPTION
There was a bug in mfterm that caused an error to be thrown even if it was previously established what to do. The bug was a result of using `if` instead of `else if`.

```
if (condition)
    something()
if (other_condition)
    something_else()
else 
    display_error()
```

Also, now `mfterm` includes `stdio` so it has access til `FILE`.
