### PR TITLE
Fixed all compilation warnings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@
 # along with mfterm.  If not, see <http://www.gnu.org/licenses/>.
 
 CC       = gcc
-CFLAGS	 = -g -Wall -Wconversion -std=c99
+CFLAGS	 = -g -Wall -Wconversion -std=c99 -Werror
 LDFLAGS  = -g -lreadline -lnfc -lssl -lcrypto
 
 LEX        = flex

--- a/mac.c
+++ b/mac.c
@@ -71,7 +71,7 @@ int compute_mac(const unsigned char* input,
  * If update is * nonzero, the mac of the current tag is updated. If
  * not, the MAC is simply printed.
  */
-unsigned char* compute_block_mac(int block,
+unsigned char* compute_block_mac(unsigned int block,
                                  const unsigned char* key,
                                  int update) {
 

--- a/mac.h
+++ b/mac.h
@@ -43,7 +43,7 @@ int compute_mac(const unsigned char* input,
  * If update is * nonzero, the mac of the current tag is updated. If
  * not, the MAC is simply printed.
  */
-unsigned char* compute_block_mac(int block,
+unsigned char* compute_block_mac(unsigned int block,
                                  const unsigned char* key,
                                  int update);
 

--- a/mifare_ctrl.c
+++ b/mifare_ctrl.c
@@ -342,7 +342,7 @@ bool mf_read_tag_internal(mf_tag_t* tag,
       uint8_t* key = key_from_tag(keys, key_type, block);
       if (!mf_authenticate(block, key, key_type)) {
         // Progress indication and error report
-        printf("0x%02x", block_to_sector(block));
+        printf("0x%02zx", block_to_sector(block));
         if (block != 3) printf(".");
         fflush(stdout);
 
@@ -360,7 +360,7 @@ bool mf_read_tag_internal(mf_tag_t* tag,
           memcpy(buffer_tag.amb[block].mbt.abtAccessBits,
                  mp.mpd.abtData + 6, 4);
         } else {
-          printf ("\nUnable to read trailer block: 0x%02x.\n", block);
+          printf ("\nUnable to read trailer block: 0x%02zx.\n", block);
           return false;
         }
         printf("."); fflush(stdout); // Progress indicator
@@ -370,7 +370,7 @@ bool mf_read_tag_internal(mf_tag_t* tag,
     else { // I.e. not a sector trailer
       // Try to read out the block
       if (!nfc_initiator_mifare_cmd(device, MC_READ, (uint8_t)block, &mp)) {
-        printf("\nUnable to read block: 0x%02x.\n", block);
+        printf("\nUnable to read block: 0x%02zx.\n", block);
         return false;
       }
       memcpy(buffer_tag.amb[block].mbd.abtData, mp.mpd.abtData, 0x10);
@@ -412,7 +412,7 @@ bool mf_write_tag_internal(const mf_tag_t* tag,
       if (!mf_authenticate(header_block, key, key_type)) {
         // Progress indication and error report
         if (header_block != 0) printf(".");
-        printf("0x%02x", block_to_sector(header_block));
+        printf("0x%02zx", block_to_sector(header_block));
         fflush(stdout);
 
         error = 1;
@@ -442,7 +442,7 @@ bool mf_write_tag_internal(const mf_tag_t* tag,
 
       // Write the data block
       if (!nfc_initiator_mifare_cmd(device, MC_WRITE, (uint8_t)block, &mp)) {
-        printf("\nUnable to write block: 0x%02x.\n", block);
+        printf("\nUnable to write block: 0x%02zx.\n", block);
         return false;
       }
     }
@@ -455,7 +455,7 @@ bool mf_write_tag_internal(const mf_tag_t* tag,
 
     // Try to write the trailer
     if (!nfc_initiator_mifare_cmd(device, MC_WRITE, (uint8_t)trailer_block, &mp)) {
-      printf("\nUnable to write block: 0x%02x.\n", trailer_block);
+      printf("\nUnable to write block: 0x%02zx.\n", trailer_block);
       return false;
     }
 
@@ -485,7 +485,7 @@ bool mf_dictionary_attack_internal(mf_tag_t* tag) {
        block_it = sector_header_iterator(size)) {
     size_t block = (size_t)block_it;
 
-    printf("Working on sector: %02x [", block_to_sector(block));
+    printf("Working on sector: %02zx [", block_to_sector(block));
 
     const uint8_t* key_a = NULL;
     const uint8_t* key_b = NULL;
@@ -566,7 +566,7 @@ bool mf_test_auth_internal(const mf_tag_t* keys,
     size_t block = (size_t)block_it;
 
     uint8_t* key = key_from_tag(keys, key_type, block);
-    printf("%02x  %c  %s  ",
+    printf("%02zx  %c  %s  ",
            block_to_sector(block),
            key_type,
            sprint_key(key));

--- a/spec_syntax.c
+++ b/spec_syntax.c
@@ -557,7 +557,7 @@ void print_instance_tree() {
     return;
   }
 
-  printf("[%d, %d] [%d, %d]  --  .  (root)\n",
+  printf("[%zu, %zu] [%zu, %zu]  --  .  (root)\n",
          instance_root->offset_bytes,
          instance_root->offset_bits,
          instance_root->size_bytes,
@@ -590,7 +590,7 @@ void print_instance_tree_(instance_t* root, int indent) {
 
 void print_instance_(instance_t* i) {
     if (i->field->type == &byte_type) {
-      printf("[%d, %d] [%d, %d]  --  Byte[%d]  %s\n",
+      printf("[%zu, %zu] [%zu, %zu]  --  Byte[%zu]  %s\n",
              i->offset_bytes,
              i->offset_bits,
              i->size_bytes,
@@ -599,7 +599,7 @@ void print_instance_(instance_t* i) {
              i->field->name);
     }
     else if (i->field->type == &bit_type) {
-      printf("[%d, %d] [%d, %d]  --  Bit[%d]  %s\n",
+      printf("[%zu, %zu] [%zu, %zu]  --  Bit[%zu]  %s\n",
              i->offset_bytes,
              i->offset_bits,
              i->size_bytes,
@@ -608,7 +608,7 @@ void print_instance_(instance_t* i) {
              i->field->name);
     }
     else {
-      printf("[%d, %d] [%d, %d]  --  %s[%d]  %s\n",
+      printf("[%zu, %zu] [%zu, %zu]  --  %s[%zu]  %s\n",
              i->offset_bytes,
              i->offset_bits,
              i->size_bytes,

--- a/tag.c
+++ b/tag.c
@@ -167,7 +167,7 @@ void print_tag_bytes(size_t first_byte, size_t last_byte) {
 void print_tag_data_range(size_t byte_offset, size_t bit_offset,
                           size_t byte_len, size_t bit_len) {
 
-  printf("Offset: [%d, %d] Length: [%d, %d]\n",
+  printf("Offset: [%zu, %zu] Length: [%zu, %zu]\n",
          byte_offset, bit_offset, byte_len, bit_len);
 
   // Print partial first byte
@@ -216,11 +216,11 @@ void print_tag_block_range(size_t first, size_t last) {
   for (size_t block = first; block <= last; ++block) {
 
     // Sector number
-    printf("%02x  ",
+    printf("%02zx  ",
            block < 0x10*4 ? block / 4 : 0x10 + (block - 0x10*4) / 0x10);
 
     // Block number
-    printf("%02x  ", block);
+    printf("%02zx  ", block);
 
     // then print the block data
     print_hex_array_sep(current_tag.amb[block].mbd.abtData,
@@ -293,11 +293,11 @@ void print_ac(const mf_tag_t* tag) {
   for (size_t block = 0; block < 0x10 * 4; ++block) {
 
     // Sector number
-    printf("%02x  ",
+    printf("%02zx  ",
            block < 0x10*4 ? block / 4 : 0x10 + (block - 0x10*4) / 0x10);
 
     // Block number
-    printf("%02x  ", block);
+    printf("%02zx  ", block);
 
     const uint8_t* ac = tag->amb[block_to_trailer(block)].mbt.abtAccessBits;
 

--- a/term_cmd.c
+++ b/term_cmd.c
@@ -277,7 +277,7 @@ int com_set(char* arg) {
     return -1;
   }
 
-  int block = strtol(block_str, &block_str, 16);
+  unsigned int block = (unsigned int) strtoul(block_str, &block_str, 16);
   if (*block_str != '\0') {
     printf("Invalid block character (non hex): %s\n", block_str);
     return -1;
@@ -287,7 +287,7 @@ int com_set(char* arg) {
     return -1;
   }
 
-  int offset = strtol(offset_str, &offset_str, 16);
+  unsigned int offset = (unsigned int) strtoul(offset_str, &offset_str, 16);
   if (*offset_str != '\0') {
     printf("Invalid offset character (non hex): %s\n", offset_str);
     return -1;
@@ -636,7 +636,7 @@ int com_mac_block_compute_impl(char* arg, int update) {
     return -1;
   }
 
-  int block = strtol(block_str, &block_str, 16);
+  unsigned int block = (unsigned int) strtoul(block_str, &block_str, 16);
   if (*block_str != '\0') {
     printf("Invalid block character (non hex): %s\n", block_str);
     return -1;


### PR DESCRIPTION
- Use %zu / %zx when printing stuff of size_t.
- Explicit typecast when using strtol/strtoul and a long is not wanted.
- Treat all warnings as errors when compiling.
