### PR TITLE
Added com_setuid command (sets tag UID, computes and stores BCC)

### DIFF
--- a/term_cmd.h
+++ b/term_cmd.h
@@ -48,6 +48,7 @@ int com_print_ac(char* arg);
 
 // Tag set (value) command
 int com_set(char* arg);
+int com_setuid(char* arg);
 
 // Key operations
 int com_keys_load(char* arg);


### PR DESCRIPTION
Useful for quickly testing block-0 rewritable cards without bothering computing BCC.